### PR TITLE
Add BsExpo.Font.loadAll and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,14 @@ export default app;
 
 Lots of easy to finish tasks, just do `yarn start` and you'll see all
 the compiler errors to fix.
+
+## Loading Fonts
+
+You will probably need to [load custom fonts](https://docs.expo.io/versions/latest/guides/using-custom-fonts.html#loading-the-font-in-your-app) and also [wait for them to load](https://docs.expo.io/versions/latest/guides/using-custom-fonts.html#waiting-for-the-font-to-load-before-rendering) before using them. You can do this using `BsExpo.Font.loadAll`:
+
+```js
+let fontsPromise = BsExpo.Font.loadAll([
+  ("MyFont", "path/to/MyFont.ttf"),
+  ("MyOtherFont", "path/to/MyOtherFont.otf"),
+]);
+```

--- a/src/font.re
+++ b/src/font.re
@@ -1,3 +1,23 @@
 [@bs.module "expo"] [@bs.scope "Font"] [@bs.val]
-external load : (string, Js.Nullable.t(string)) => Js.Promise.t(unit) =
+external _load : (string, Js.Nullable.t(string)) => Js.Promise.t(unit) =
   "loadAsync";
+
+let load = (name, path) => {
+  Js.log("[Deprecated] Please use loadAll instead");
+  _load(name, path)
+};
+
+type fontModule;
+
+[@bs.val]
+external require : (string) => fontModule = "";
+
+[@bs.module "expo"] [@bs.scope "Font"] [@bs.val]
+external loadDict : (Js.Dict.t(fontModule)) => Js.Promise.t(unit) =
+  "loadAsync";
+
+let loadAll = (fonts) =>
+  List.map(((name,path)) => (name, require(path)), fonts)
+  |> Js.Dict.fromList
+  |> loadDict
+;

--- a/src/font.rei
+++ b/src/font.rei
@@ -1,0 +1,2 @@
+let load: (string, Js.Nullable.t(string)) => Js.Promise.t(unit);
+let loadAll: list((Js.Dict.key, string)) => Js.Promise.t(unit);


### PR DESCRIPTION
Warning: I did something opinionated. I deprecated `BsExpo.Font.load` in favor of `BsExpo.Font.loadAll`. I didn't think it was worth having two functions that do the same thing. But if you disagree I will undo the deprecation.