### PR TITLE
Improve AppLoading API, supporting it completely

### DIFF
--- a/src/components/appLoading.re
+++ b/src/components/appLoading.re
@@ -3,11 +3,15 @@ external app_loading : ReasonReact.reactClass = "AppLoading";
 
 let make =
     (
-      ~startAsync: unit => Js.Promise.t(unit),
-      ~onError: unit => unit,
-      ~onFinish: unit => unit
+      ~startAsync: option(unit => Js.Promise.t('a))=?,
+      ~onError: option('a => unit)=?,
+      ~onFinish: option(unit => unit)=?,
     ) =>
   ReasonReact.wrapJsForReason(
     ~reactClass=app_loading,
-    ~props={"startAsync": startAsync, "onError": onError, "onFinish": onFinish}
+    ~props={
+      "startAsync": Js.Nullable.fromOption(startAsync),
+      "onError": Js.Nullable.fromOption(onError),
+      "onFinish": Js.Nullable.fromOption(onFinish),
+    },
   );


### PR DESCRIPTION
This change allows users to use AppLoading as a component without props and manage the transition on their own, or use AppLoading's [async handlers](https://docs.expo.io/versions/latest/sdk/app-loading.html#startasync-function--a-function-that-returns-a-promise-and-the-promise-should-resolve-when-the-app-is-done-loading-required-data-and-assets).
Here's some [working code](https://github.com/fiber-god/pico/blob/de1e2c3e6a0c16d492f61631f057110e89fc97fa/src/App.re#L82).