### PR TITLE
Improve Font Bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,9 @@ the compiler errors to fix.
 
 You will probably need to [load custom fonts](https://docs.expo.io/versions/latest/guides/using-custom-fonts.html#loading-the-font-in-your-app) and also [wait for them to load](https://docs.expo.io/versions/latest/guides/using-custom-fonts.html#waiting-for-the-font-to-load-before-rendering) before using them. You can do this using `BsExpo.Font.loadAll`:
 
-```js
+```reason
 let fontsPromise = BsExpo.Font.loadAll([
-  ("MyFont", "path/to/MyFont.ttf"),
-  ("MyOtherFont", "path/to/MyOtherFont.otf"),
+  ("MyFont",  BsReactNative.Packager.require("path/to/MyFont.ttf")),
+  ("MyOtherFont", BsReactNative.Packager.require("path/to/MyOtherFont.otf")),
 ]);
 ```

--- a/src/Font.re
+++ b/src/Font.re
@@ -1,23 +1,10 @@
-[@bs.module "expo"] [@bs.scope "Font"] [@bs.val]
-external _load : (string, Js.Nullable.t(string)) => Js.Promise.t(unit) =
-  "loadAsync";
-
-let load = (name, path) => {
-  Js.log("[Deprecated] Please use loadAll instead");
-  _load(name, path)
-};
-
-type fontModule;
-
-[@bs.val]
-external require : (string) => fontModule = "";
+open BsReactNative;
 
 [@bs.module "expo"] [@bs.scope "Font"] [@bs.val]
-external loadDict : (Js.Dict.t(fontModule)) => Js.Promise.t(unit) =
+external loadDict : Js.Dict.t(Packager.required) => Js.Promise.t(unit) =
   "loadAsync";
 
-let loadAll = (fonts) =>
-  List.map(((name,path)) => (name, require(path)), fonts)
+let loadAll = fonts =>
+  List.map(((name, font: Packager.required)) => (name, font), fonts)
   |> Js.Dict.fromList
-  |> loadDict
-;
+  |> loadDict;

--- a/src/Font.rei
+++ b/src/Font.rei
@@ -1,2 +1,0 @@
-let load: (string, Js.Nullable.t(string)) => Js.Promise.t(unit);
-let loadAll: list((Js.Dict.key, string)) => Js.Promise.t(unit);


### PR DESCRIPTION
Uses BsReactNative-provided Packager.required type instead of loosely created fontModule type and require bindings