### PR TITLE
Refactor Js.boolean to bool

### DIFF
--- a/src/AdMob.re
+++ b/src/AdMob.re
@@ -105,7 +105,7 @@ module Interstitial = {
   [@bs.module "expo"] [@bs.scope "AdMobInterstitial"] [@bs.val]
   external showAd : ('a => unit) => unit = "showAd";
   [@bs.module "expo"] [@bs.scope "AdMobInterstitial"] [@bs.val]
-  external isReady : (Js.boolean => unit) => unit = "isReady";
+  external isReady : (bool => unit) => unit = "isReady";
 };
 
 module Rewarded = {

--- a/src/Audio.re
+++ b/src/Audio.re
@@ -32,8 +32,7 @@ type audioMode = {
 };
 
 [@bs.module "expo"] [@bs.scope "Audio"] [@bs.val]
-external setAudioModeAsync : Js.boolean => Js.Promise.t(unit) =
-  "setAudioModeAsync";
+external setAudioModeAsync : bool => Js.Promise.t(unit) = "setAudioModeAsync";
 /*
  type sound = {
    .

--- a/src/Constants.re
+++ b/src/Constants.re
@@ -19,15 +19,15 @@ type t('env) = {
     "developer": {
       .
       "projectRoot": string,
-      "tool": string
+      "tool": string,
     },
     "env": Js.t({..} as 'env),
     "icon": string,
     "iconUrl": string,
     "id": string,
-    "isVerified": Js.boolean,
-    "logUrl": string
-  }
+    "isVerified": bool,
+    "logUrl": string,
+  },
 };
 
 [@bs.val] [@bs.module "expo"] external constants : t('env) = "Constants";

--- a/src/Contacts.re
+++ b/src/Contacts.re
@@ -22,7 +22,7 @@ type contacts_pagination_result = {
     "previousLastName": Js.Undefined.t(string),
   },
   "hasNextPage": Js.boolean,
-  "hasPreviousPage": Js.boolean,
+  "hasPreviousPage": bool,
   "total": int,
 };
 

--- a/src/FileSystem.re
+++ b/src/FileSystem.re
@@ -17,7 +17,7 @@ type fileInfo = {
 type options = {
   .
   "md5": Js.Undefined.t(Js.boolean),
-  "size": Js.Undefined.t(Js.boolean),
+  "size": Js.Undefined.t(bool),
 };
 
 [@bs.module "expo"] [@bs.scope "FileSystem"]

--- a/src/Fingerprint.re
+++ b/src/Fingerprint.re
@@ -11,7 +11,7 @@ external authenticateAsync :
   Js.nullable(string) =>
   {
     .
-    success: Js.boolean,
+    success: bool,
     error: Js.nullable(string),
   } =
   "authenticateAsync";

--- a/src/ImagePicker.re
+++ b/src/ImagePicker.re
@@ -4,22 +4,22 @@ type image_t = {
   .
   "uri": string,
   "width": int,
-  "height": int
+  "height": int,
 };
 
 type image_library_opts = {
   .
-  "allowsEditing": Js.undefined(Js.boolean),
+  "allowsEditing": Js.undefined(bool),
   "aspect": Js.undefined((int, int)),
   "quality": Js.undefined(int),
-  "mediaTypes": Js.undefined(media_t)
+  "mediaTypes": Js.undefined(media_t),
 };
 
 type camera_opts = {
   .
-  "allowsEditing": Js.undefined(Js.boolean),
+  "allowsEditing": Js.undefined(bool),
   "aspect": Js.undefined((int, int)),
-  "quality": Js.undefined(int)
+  "quality": Js.undefined(int),
 };
 /* type image_result = { */
 /*   . */


### PR DESCRIPTION
PLEASE REVIEW THIS!

I am rather new to ReasonML but I think that Js.boolean is deprecated and we can use just the ReasonML type bool instead. right??

See https://reasonml.github.io/docs/en/boolean (Usage note)